### PR TITLE
fix/169-highlighted_in_red_fields_log_in

### DIFF
--- a/slidez-fe-core/src/common/components/forms/LoginForm.tsx
+++ b/slidez-fe-core/src/common/components/forms/LoginForm.tsx
@@ -108,7 +108,7 @@ const LoginForm = ({ onLogin, onLoginWithGoogle }: LoginProps) => {
                                 name='email'
                                 className={
                                     'form-input' +
-                                    (viewErrors && errors.email
+                                    (viewErrors && (errors.email || loginError)
                                         ? ' error-input'
                                         : '')
                                 }
@@ -138,7 +138,8 @@ const LoginForm = ({ onLogin, onLoginWithGoogle }: LoginProps) => {
                                     name='password'
                                     className={
                                         'form-input input-with-icon' +
-                                        (viewErrors && errors.password
+                                        (viewErrors &&
+                                        (errors.password || loginError)
                                             ? ' error-input'
                                             : '')
                                     }


### PR DESCRIPTION
Email and Password inputs shall be highlighted in red after filling invalid data and clicking the Log in button
