### PR TITLE
Fix/294 poll without options shouldn't be possible to create

### DIFF
--- a/slidez-fe-core/src/containers/poll-editor/PollEditor.scss
+++ b/slidez-fe-core/src/containers/poll-editor/PollEditor.scss
@@ -139,3 +139,6 @@
         text-align: center;
     }
 }
+.error-input {
+    border-color: $error;
+}

--- a/slidez-fe-core/src/containers/poll-editor/PollEditor.tsx
+++ b/slidez-fe-core/src/containers/poll-editor/PollEditor.tsx
@@ -19,7 +19,7 @@ export type PollEditorProps = {
     pollId?: string | null
 }
 
-type LivePollErorrsProps = {
+type LivePollErrorsProps = {
     viewErrors: boolean
     formikErrors: FormikErrors<{
         title: string
@@ -41,7 +41,7 @@ const livePollFieldsValidation = Yup.object({
         ),
 })
 
-const LivePollErrors = ({ viewErrors, formikErrors }: LivePollErorrsProps) => {
+const LivePollErrors = ({ viewErrors, formikErrors }: LivePollErrorsProps) => {
     let errorMessage: string | null = null
     if (!viewErrors) {
         errorMessage = null

--- a/slidez-fe-core/src/containers/poll-editor/PollEditor.tsx
+++ b/slidez-fe-core/src/containers/poll-editor/PollEditor.tsx
@@ -1,5 +1,3 @@
-import { faTrashAlt } from '@fortawesome/free-regular-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Field, FieldArray, Form, Formik, FormikErrors } from 'formik'
 import React, { useState, useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
@@ -145,8 +143,8 @@ const PollEditor: React.FC<PollEditorProps> = ({ pollId }: PollEditorProps) => {
                     <Formik
                         initialValues={initialValues}
                         validationSchema={livePollFieldsValidation}
-                        onSubmit={({ title, options }, { setSubmitting }) => {
-                            handleSubmit({ title, options })
+                        onSubmit={(values, { setSubmitting }) => {
+                            handleSubmit(values)
                             setSubmitting(false)
                         }}
                     >


### PR DESCRIPTION
Show error validation message (as we make on email) for poll creation
- Poll name should be longer than 2 symbols
- Options can't be empty if they added
- Poll without options or with empty options can't be created
